### PR TITLE
[TR-8] Accepted invites become participants

### DIFF
--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -31,6 +31,7 @@ class TripsController < ApplicationController
   def build_trip
     @trip ||= trip_scope.build
     @trip.attributes = trip_params
+    @trip.organiser = current_user
   end
 
   def save_trip
@@ -38,7 +39,7 @@ class TripsController < ApplicationController
   end
 
   def trip_scope
-    Trip.where(organiser: current_user)
+    current_user.trips
   end
 
   def trip_params

--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -4,4 +4,11 @@ class Trip < ApplicationRecord
   has_many :trip_participants
   has_many :participants, through: :trip_participants, source: :user
   has_many :invites
+  after_create :organiser_is_a_participant
+
+  private
+
+  def organiser_is_a_participant
+    participants << organiser
+  end
 end

--- a/app/models/trip/invite.rb
+++ b/app/models/trip/invite.rb
@@ -11,6 +11,7 @@ class Trip::Invite < ApplicationRecord
   validates :email, format: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\Z/i, on: :create
 
   after_update :update_responded_at, if: :rvsp_changed?
+  after_update :invite_accepted, if: :rvsp_changed?
   after_create :send_invite
 
   def responded?
@@ -18,6 +19,10 @@ class Trip::Invite < ApplicationRecord
   end
 
   private
+
+  def invite_accepted
+    Trip::InviteManager.invite_accepted(invite: self, email: email) if rvsp
+  end
 
   def update_responded_at
     touch :responded_at

--- a/app/models/trip/invite_manager.rb
+++ b/app/models/trip/invite_manager.rb
@@ -1,0 +1,24 @@
+class Trip::InviteManager
+  class << self
+    def add_trips_to(user)
+      accepted_invites_for(user.email).each do |invite|
+        add_participant_to_trip(user: user, trip: invite.trip)
+      end
+    end
+
+    def invite_accepted(invite:, email:)
+      user = User.find_by(email: email)
+      add_participant_to_trip(user: user, trip: invite.trip) if user
+    end
+
+    private
+
+    def add_participant_to_trip(user:, trip:)
+      user.trips << trip unless user.trips.include?(trip)
+    end
+
+    def accepted_invites_for(email)
+      Trip::Invite.where(email: email, rvsp: true)
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,11 @@ class User < ApplicationRecord
   validates :username, presence: true
   has_many :trip_participants
   has_many :trips, through: :trip_participants
+  after_create :add_trips
+
+  private
+
+  def add_trips
+    Trip::InviteManager.add_trips_to(self)
+  end
 end

--- a/spec/features/helpers/users.rb
+++ b/spec/features/helpers/users.rb
@@ -1,5 +1,5 @@
-def login_user
-  user = FactoryGirl.create(:user)
+def login_user(user = nil)
+  user ||= FactoryGirl.create(:user)
   login_as(user)
   visit('/')
 end

--- a/spec/features/trip_feature_spec.rb
+++ b/spec/features/trip_feature_spec.rb
@@ -67,6 +67,17 @@ feature 'Trip' do
     expect(page).to have_content('Declined')
     expect(page).to have_content('Pending')
   end
+
+  scenario 'An existing user is added to participants if accepts invite' do
+    organiser = create(:user)
+    invitee = create(:user)
+    trip = create(:trip, organiser: organiser)
+    trip_invite = create(:trip_invite, trip: trip, email: invitee.email)
+    trip_invite.update!(rvsp: true)
+    login_user(invitee)
+    click_link('My trips')
+    expect(page).to have_content('My description')
+  end
 end
 
 def create_trip(name:, description:)

--- a/spec/features/user_feature_spec.rb
+++ b/spec/features/user_feature_spec.rb
@@ -24,6 +24,18 @@ feature 'User can sign in and out' do
   end
 end
 
+feature 'Add invitations when signup' do
+  context 'Accepted invite' do
+    scenario 'A user can see trips accepted when joining' do
+      create(:trip_invite, email: 'invite@email.com', rvsp: true, responded_at: Time.zone.now)
+      sign_up(email: 'invite@email.com')
+      click_link('My trips')
+      expect(page).to have_content('My trip')
+      expect(page).to have_content('My description')
+    end
+  end
+end
+
 def sign_up(name: 'Name', email: 'test@example.com', password: 'testtest')
   visit('/')
   click_link('Sign up')

--- a/spec/models/trip/invite_manager_spec.rb
+++ b/spec/models/trip/invite_manager_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+describe Trip::InviteManager do
+  let(:manager) { described_class }
+  let(:user) { create(:user) }
+
+  describe '.add_trips_to' do
+    context 'when invite accepted' do
+      it 'adds user to trips' do
+        invite = create(:trip_invite, email: user.email, rvsp: true, responded_at: Time.zone.now)
+        manager.add_trips_to(user)
+
+        expect(user.trips).to eq([invite.trip])
+      end
+
+      it 'only adds trip if it is unique' do
+        trip = create(:trip, organiser: user)
+        create(:trip_invite, trip: trip, email: user.email, rvsp: true, responded_at: Time.zone.now)
+
+        manager.add_trips_to(user)
+        expect(user.trips).to eq([trip])
+      end
+    end
+
+    context 'when invite not accepted' do
+      it 'does not add the user to trips' do
+        invite = create(:trip_invite, email: user.email, rvsp: false, responded_at: Time.zone.now)
+        manager.add_trips_to(user)
+
+        expect(user.trips).not_to include(invite.trip)
+      end
+    end
+  end
+
+  describe '.invite_accepted' do
+    context 'user already exists' do
+      it 'adds the user as participant' do
+        invite = create(:trip_invite, email: user.email, rvsp: true, responded_at: Time.zone.now)
+        manager.invite_accepted(invite: invite, email: user.email)
+
+        expect(user.trips).to eq([invite.trip])
+      end
+    end
+
+    context 'user doesnt exist' do
+      it 'adds the user as participant' do
+        email = 'invite@email.com'
+        invite = create(:trip_invite, email: email, rvsp: true, responded_at: Time.zone.now)
+        expect { manager.invite_accepted(invite: invite, email: email) }
+          .not_to change { invite.trip.participants.count }
+      end
+    end
+  end
+end

--- a/spec/models/trip/invite_spec.rb
+++ b/spec/models/trip/invite_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 describe Trip::Invite do
   let(:trip_invite) { described_class }
+  let(:invite) { create(:trip_invite) }
 
   describe 'validations' do
     it 'factory girl is valid' do
@@ -51,6 +52,18 @@ describe Trip::Invite do
 
     it 'sends an email' do
       expect { create(:trip_invite) }.to change { ActionMailer::Base.deliveries.count }.by(1)
+    end
+  end
+
+  describe 'rvsp' do
+    it 'if rvsp set to true, makes call to TripInviteManager to add user' do
+      expect(Trip::InviteManager).to receive(:invite_accepted)
+      invite.update!(rvsp: true)
+    end
+
+    it 'if rvsp is set to false, does not make call TripInviteManager' do
+      expect(Trip::InviteManager).to receive(:invite_accepted).never
+      invite.update!(rvsp: false)
     end
   end
 

--- a/spec/models/trip_spec.rb
+++ b/spec/models/trip_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe Trip do
+  let(:trip) { create(:trip) }
+
   describe 'validations' do
     it 'factory girl is valid' do
       trip = create(:trip)
@@ -15,6 +17,12 @@ describe Trip do
     it 'a trip is invalid without a creator' do
       trip = Trip.create(name: 'bla')
       expect(trip).to be_invalid
+    end
+  end
+
+  describe 'participants' do
+    it 'an organiser is automatically a participant' do
+      expect(trip.participants).to include(trip.organiser)
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
 describe User do
-  let(:user_attributes) { attributes_for(:user) }
+  let(:user) { create(:user) }
 
   describe 'validations' do
+    let(:user_attributes) { attributes_for(:user) }
     it 'factory girl is valid' do
-      user = create(:user)
       expect(user).to be_valid
     end
 
@@ -25,6 +25,13 @@ describe User do
 
       user = User.create(user_attributes)
       expect(user).not_to be_valid
+    end
+  end
+
+  describe 'add_user_to_invites' do
+    it 'calls the trip_invite to add_user' do
+      expect(Trip::InviteManager).to receive(:add_trips_to)
+      user
     end
   end
 end


### PR DESCRIPTION
When an existing user accepts a trip invite, or a new user has accepted
and invite, and then signs up, the user becomes a participant.

Create invite manager to manage when an invite becomes a participant.