### PR TITLE
[TR-17] Creator can delete input

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,5 +1,6 @@
 class CommentsController < ApplicationController
   before_action :authenticate_user!
+  load_and_authorize_resource only: :destroy
 
   def new
     build_comment
@@ -8,6 +9,12 @@ class CommentsController < ApplicationController
   def create
     build_comment
     save_comment || render(:new)
+  end
+
+  def destroy
+    trip = @comment.commentable.trip
+    @comment.destroy
+    redirect_to trip_path(trip)
   end
 
   private

--- a/app/controllers/trips/date_options_controller.rb
+++ b/app/controllers/trips/date_options_controller.rb
@@ -1,5 +1,6 @@
 class Trips::DateOptionsController < ApplicationController
   before_action :authenticate_user!
+  load_and_authorize_resource class: "Trip::DateOption", only: :destroy
 
   def new
     build_date
@@ -10,11 +11,18 @@ class Trips::DateOptionsController < ApplicationController
     save_date || render(:new)
   end
 
+  def destroy
+    trip = @date_option.trip
+    @date_option.destroy
+    redirect_to trip_path(trip)
+  end
+
   private
 
   def build_date
     @date ||= date_scope.build
     @date.attributes = date_params
+    @date.creator = trip_participant
   end
 
   def save_date
@@ -23,6 +31,10 @@ class Trips::DateOptionsController < ApplicationController
 
   def trip
     @trip ||= Trip.find(params[:trip_id])
+  end
+
+  def trip_participant
+    @trip.trip_participants.where(user: current_user).first
   end
 
   def date_scope

--- a/app/controllers/trips/destinations_controller.rb
+++ b/app/controllers/trips/destinations_controller.rb
@@ -1,5 +1,6 @@
 class Trips::DestinationsController < ApplicationController
   before_action :authenticate_user!
+  load_and_authorize_resource class: "Trip::Destination", only: :destroy
 
   def new
     build_destination
@@ -10,15 +11,26 @@ class Trips::DestinationsController < ApplicationController
     save_destination || render(:new)
   end
 
+  def destroy
+    trip = @destination.trip
+    @destination.destroy
+    redirect_to trip_path(trip)
+  end
+
   private
 
   def build_destination
     @destination ||= destination_scope.build
     @destination.attributes = destination_params
+    @destination.creator = trip_participant
   end
 
   def save_destination
     redirect_to @trip if @destination.save
+  end
+
+  def trip_participant
+    @trip.trip_participants.where(user: current_user).first
   end
 
   def trip

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -8,11 +8,17 @@ class Ability
     end
     can [:manage], Trip, organiser: user
     can [:destroy], Trip::Invite do |invite|
-      Trip.find(invite.trip_id).organiser == user
+      invite.trip.organiser == user
     end
 
-    can [:read, :create], Trip::InviteBuilder do |builder|
-      Trip.find(builder.trip_id).participants.include?(user)
+    can [:destroy], Trip::Destination do |destination|
+      user.trip_participants.include?(destination.creator)
     end
+
+    can [:destroy], Trip::DateOption do |date_option|
+      user.trip_participants.include?(date_option.creator)
+    end
+
+    can [:destroy], Comment, author: user
   end
 end

--- a/app/models/trip/date_option.rb
+++ b/app/models/trip/date_option.rb
@@ -1,5 +1,6 @@
 class Trip::DateOption < ApplicationRecord
   belongs_to :trip
+  belongs_to :creator, class_name: "TripParticipant"
   validates :range, presence: true
   has_many :comments, as: :commentable, dependent: :delete_all
   has_many :votes, as: :votable, dependent: :delete_all

--- a/app/models/trip/destination.rb
+++ b/app/models/trip/destination.rb
@@ -1,6 +1,7 @@
 class Trip::Destination < ApplicationRecord
   belongs_to :trip
-  has_many :comments, as: :commentable, dependent: :delete_all
-  has_many :votes, as: :votable, dependent: :delete_all
+  belongs_to :creator, class_name: "TripParticipant"
+  has_many :comments, as: :commentable, dependent: :destroy
+  has_many :votes, as: :votable, dependent: :destroy
   validates :name, presence: true
 end

--- a/app/models/trip_participant.rb
+++ b/app/models/trip_participant.rb
@@ -1,4 +1,6 @@
 class TripParticipant < ApplicationRecord
   belongs_to :trip
   belongs_to :user
+  has_many :destinations, dependent: :destroy, class_name: "Trip::Destination", foreign_key: "creator_id"
+  has_many :date_options, dependent: :destroy, class_name: "Trip::DateOption", foreign_key: "creator_id"
 end

--- a/app/views/trips/_comments.html.haml
+++ b/app/views/trips/_comments.html.haml
@@ -1,4 +1,6 @@
 %p Comments:
 - commentable.comments.each do |comment|
   %p #{comment.author.username}: #{comment.text} at #{comment.added_at}
+  - if can? :destroy, comment
+    = link_to 'Remove', comment_path(comment), method: :delete
 = link_to "Add comment", new_comment_path(commentable_type: commentable_type, commentable_id: commentable.id)

--- a/app/views/trips/_destinations.html.haml
+++ b/app/views/trips/_destinations.html.haml
@@ -1,0 +1,9 @@
+- destinations.each do |destination|
+  %li
+    .card
+      .card-section
+        %h1= destination.name + ": " + destination.description
+        - if can? :destroy, destination
+          = link_to 'Remove', destination_path(destination), method: :delete
+        = render partial: "votes", locals: { votable: destination, votable_type: 'trip/destination', id_type: 'destination' }
+        = render partial: "comments", locals: { commentable: destination, commentable_type: 'trip/destination' }

--- a/app/views/trips/show.html.haml
+++ b/app/views/trips/show.html.haml
@@ -14,18 +14,25 @@
     .small-12.columns
       .frame
         %ul.slidee
-          - @trip.destinations.each do |destination|
+          = render partial: "destinations", locals: { destinations: @trip.destinations }
+
+  .row
+    .small-8.columns
+      %h3.uppercase Dates:
+    .small-3.columns
+      = link_to "Add date", new_trip_date_option_path(@trip), class: 'button'
+
+.section
+  .row
+    .small-12.columns
+      .frame
+        %ul.slidee
+          - @trip.date_options.each do |date|
             %li
               .card
                 .card-section
-                  %h1= destination.name + ": " + destination.description
-                  = render partial: "votes", locals: { votable: destination, votable_type: 'trip/destination', id_type: 'destination' }
-                  = render partial: "comments", locals: { commentable: destination, commentable_type: 'trip/destination' }
-
-      %h3 Dates:
-      %p= link_to "Add date", new_trip_date_option_path(@trip), class: 'button'
-
-      - @trip.date_options.each do |date|
-        %p= date.range
-        = render partial: "votes", locals: { votable: date, votable_type: 'trip/date_option', id_type: 'date_option' }
-        = render partial: "comments", locals: { commentable: date, commentable_type: 'trip/date_option' }
+                  %h1= date.range
+                  - if can? :destroy, date
+                    = link_to 'Remove', date_option_path(date), method: :delete
+                  = render partial: "votes", locals: { votable: date, votable_type: 'trip/date_option', id_type: 'date_option' }
+                  = render partial: "comments", locals: { commentable: date, commentable_type: 'trip/date_option' }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,14 +4,14 @@ Rails.application.routes.draw do
   root to: "home#index"
   resource :home, only: [:index]
   resources :trips, only: [:new, :create, :show, :index, :destroy], shallow: true do
-    resources :destinations, only: [:new, :create], controller: "trips/destinations"
-    resources :date_options, only: [:new, :create], controller: "trips/date_options"
+    resources :destinations, only: [:new, :create, :destroy], controller: "trips/destinations"
+    resources :date_options, only: [:new, :create, :destroy], controller: "trips/date_options"
 
     resources :invites, only: [:new, :create, :destroy], controller: "trips/invites" do
       get :rvsp, on: :member
     end
   end
 
-  resources :comments, only: [:new, :create]
+  resources :comments, only: [:new, :create, :destroy]
   resources :votes, only: [:create]
 end

--- a/db/migrate/20170407131304_add_creator_to_destination_and_date_option.rb
+++ b/db/migrate/20170407131304_add_creator_to_destination_and_date_option.rb
@@ -1,0 +1,6 @@
+class AddCreatorToDestinationAndDateOption < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :trip_destinations, :creator, foreign_key: { to_table: :trip_participants }
+    add_reference :trip_date_options, :creator, foreign_key: { to_table: :trip_participants }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170331120429) do
+ActiveRecord::Schema.define(version: 20170407131304) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -32,6 +32,8 @@ ActiveRecord::Schema.define(version: 20170331120429) do
     t.integer  "trip_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer  "creator_id"
+    t.index ["creator_id"], name: "index_trip_date_options_on_creator_id", using: :btree
     t.index ["trip_id"], name: "index_trip_date_options_on_trip_id", using: :btree
   end
 
@@ -41,6 +43,8 @@ ActiveRecord::Schema.define(version: 20170331120429) do
     t.integer  "trip_id"
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
+    t.integer  "creator_id"
+    t.index ["creator_id"], name: "index_trip_destinations_on_creator_id", using: :btree
     t.index ["trip_id"], name: "index_trip_destinations_on_trip_id", using: :btree
   end
 
@@ -105,5 +109,7 @@ ActiveRecord::Schema.define(version: 20170331120429) do
     t.index ["voter_id"], name: "index_votes_on_voter_id", using: :btree
   end
 
+  add_foreign_key "trip_date_options", "trip_participants", column: "creator_id"
+  add_foreign_key "trip_destinations", "trip_participants", column: "creator_id"
   add_foreign_key "trips", "users"
 end

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -1,52 +1,84 @@
 require 'rails_helper'
 
 describe CommentsController do
-  let(:destination) { create(:trip_destination, trip: create(:trip, organiser: User.last)) }
+  let(:user) { create(:user) }
+  let(:destination) { create(:trip_destination, trip: create(:trip, organiser: user)) }
   let(:date_option) { create(:trip_date_option) }
 
-  login_user
+  context 'when not logged in' do
+    it 'redirects to sign in path' do
+      post :create, params:
+        {
+          commentable_type: 'trip/destination',
+          commentable_id: destination.id,
+          comment: { text: 'my comment' }
+        }
 
-  describe '#create' do
-    context 'when successful' do
-      context 'polymorphic destination' do
-        before do
-          post :create, params:
-            {
-              commentable_type: 'trip/destination',
-              commentable_id: destination.id,
-              comment: { text: 'my comment' }
-            }
+      expect(response).to redirect_to(new_user_session_path)
+    end
+  end
+
+  context 'when logged in' do
+    before { sign_in user }
+
+    describe '#create' do
+      context 'when successful' do
+        context 'polymorphic destination' do
+          before do
+            post :create, params:
+              {
+                commentable_type: 'trip/destination',
+                commentable_id: destination.id,
+                comment: { text: 'my comment' }
+              }
+          end
+
+          it 'adds a comment to the destination' do
+            expect(destination.comments.count).to eq(1)
+          end
+
+          it 'redirects to trip path' do
+            expect(response).to redirect_to(trip_path(destination.trip))
+          end
+
+          it 'adds the current user as the author' do
+            expect(destination.comments.last.author).to eq(User.last)
+          end
         end
 
-        it 'adds a comment to the destination' do
-          expect(destination.comments.count).to eq(1)
-        end
+        context 'polymorphic date option' do
+          before do
+            post :create, params:
+              {
+                commentable_type: 'trip/date_option',
+                commentable_id: date_option.id,
+                comment: { text: 'my comment' }
+              }
+          end
 
-        it 'redirects to trip path' do
-          expect(response).to redirect_to(trip_path(destination.trip))
-        end
+          it 'adds a comment to the date_option' do
+            expect(date_option.comments.count).to eq(1)
+          end
 
-        it 'adds the current user as the author' do
-          expect(destination.comments.last.author).to eq(User.last)
+          it 'redirects to trip path' do
+            expect(response).to redirect_to(trip_path(date_option.trip))
+          end
         end
       end
+    end
 
-      context 'polymorphic date option' do
-        before do
-          post :create, params:
-            {
-              commentable_type: 'trip/date_option',
-              commentable_id: date_option.id,
-              comment: { text: 'my comment' }
-            }
+    describe '#destroy' do
+      context 'when the creator' do
+        let!(:comment) { create(:comment, author: user) }
+
+        it 'deletes the comment' do
+          expect { post :destroy, params: { id: comment.id } }.to change { Trip::Comment.all.count }.by(-1)
         end
 
-        it 'adds a comment to the date_option' do
-          expect(date_option.comments.count).to eq(1)
-        end
-
-        it 'redirects to trip path' do
-          expect(response).to redirect_to(trip_path(date_option.trip))
+        it 'redirects to trips path' do
+          trip = comment.commentable.trip
+          post :destroy, params: { id: comment.id }
+          expect(response).to redirect_to(trip_path(trip))
         end
       end
     end

--- a/spec/controllers/trips/date_options_controller_spec.rb
+++ b/spec/controllers/trips/date_options_controller_spec.rb
@@ -2,20 +2,52 @@ require 'rails_helper'
 
 describe Trips::DateOptionsController do
   let(:trip) { create(:trip) }
-  login_user
+  let(:user) { trip.organiser }
 
-  describe '#create' do
-    context 'when successful' do
-      before do
-        post :create, params: { trip_id: trip.id, trip_date_option: { range: '17/03/2017 - 20/03/17' } }
+  context 'when not logged in' do
+    it 'redirects to sign in path' do
+      post :create, params: { trip_id: trip.id, trip_date_option: { range: '17/03/2017 - 20/03/17' } }
+
+      expect(response).to redirect_to(new_user_session_path)
+    end
+  end
+
+  context 'when logged in' do
+    before { sign_in user }
+
+    describe '#create' do
+      context 'when successful' do
+        before do
+          post :create, params: { trip_id: trip.id, trip_date_option: { range: '17/03/2017 - 20/03/17' } }
+        end
+
+        it 'adds a date to the trip' do
+          expect(trip.date_options.count).to eq(1)
+        end
+
+        it 'adds the creator' do
+          expect(trip.date_options.last.creator).to eq(user.trip_participants.last)
+        end
+
+        it 'redirects to trip path' do
+          expect(response).to redirect_to(trip_path(trip))
+        end
       end
+    end
 
-      it 'adds a date to the trip' do
-        expect(trip.date_options.count).to eq(1)
-      end
+    describe '#destroy' do
+      context 'when the creator' do
+        let!(:date_option) { create(:trip_date_option, trip: trip, creator: user.trip_participants.first) }
 
-      it 'redirects to trip path' do
-        expect(response).to redirect_to(trip_path(trip))
+        it 'deletes the date_option' do
+          expect { post :destroy, params: { id: date_option.id } }.to change { Trip::DateOption.all.count }.by(-1)
+        end
+
+        it 'redirects to trips path' do
+          trip = date_option.trip
+          post :destroy, params: { id: date_option.id }
+          expect(response).to redirect_to(trip_path(trip))
+        end
       end
     end
   end

--- a/spec/controllers/trips/destinations_controller_spec.rb
+++ b/spec/controllers/trips/destinations_controller_spec.rb
@@ -2,19 +2,49 @@ require 'rails_helper'
 
 describe Trips::DestinationsController do
   let(:trip) { create(:trip) }
+  let(:user) { trip.organiser }
 
-  login_user
+  context 'when not logged in' do
+    it 'redirects to sign in path' do
+      post :create, params: { trip_id: trip.id, trip_destination: { name: 'Sarajevo' } }
+      expect(response).to redirect_to(new_user_session_path)
+    end
+  end
 
-  describe '#create' do
-    context 'when successful' do
-      before { post :create, params: { trip_id: trip.id, trip_destination: { name: 'Sarajevo' } } }
+  context 'when logged in' do
+    before { sign_in user }
 
-      it 'adds a destination to the trip' do
-        expect(trip.destinations.count).to eq(1)
+    describe '#create' do
+      context 'when successful' do
+        before { post :create, params: { trip_id: trip.id, trip_destination: { name: 'Sarajevo' } } }
+
+        it 'adds a destination to the trip' do
+          expect(trip.destinations.count).to eq(1)
+        end
+
+        it 'adds the creator' do
+          expect(trip.destinations.last.creator).to eq(user.trip_participants.last)
+        end
+
+        it 'redirects to trip path' do
+          expect(response).to redirect_to(trip_path(trip))
+        end
       end
+    end
 
-      it 'redirects to trip path' do
-        expect(response).to redirect_to(trip_path(trip))
+    describe '#destroy' do
+      context 'when the creator' do
+        let!(:destination) { create(:trip_destination, trip: trip, creator: user.trip_participants.first) }
+
+        it 'deletes the destination' do
+          expect { post :destroy, params: { id: destination.id } }.to change { Trip::Destination.all.count }.by(-1)
+        end
+
+        it 'redirects to trips path' do
+          trip = destination.trip
+          post :destroy, params: { id: destination.id }
+          expect(response).to redirect_to(trip_path(trip))
+        end
       end
     end
   end

--- a/spec/factories/trip_date_options.rb
+++ b/spec/factories/trip_date_options.rb
@@ -2,5 +2,6 @@ FactoryGirl.define do
   factory :trip_date_option, class: 'Trip::DateOption' do
     range '17/03/2017 - 20/03/2017'
     trip
+    creator { trip.organiser.trip_participants.first }
   end
 end

--- a/spec/factories/trip_destinations.rb
+++ b/spec/factories/trip_destinations.rb
@@ -1,6 +1,8 @@
 FactoryGirl.define do
   factory :trip_destination, class: 'Trip::Destination' do
     name 'Sarajevo'
+    description 'Best city in Europe'
     trip
+    creator { trip.organiser.trip_participants.first }
   end
 end

--- a/spec/factories/trips.rb
+++ b/spec/factories/trips.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :trip do
-    name 'Sarajevo'
-    description 'Let us meet there'
+    name 'Reunion'
+    description 'Let us organise it'
     association :organiser, factory: :user
   end
 end

--- a/spec/features/comment_feature_spec.rb
+++ b/spec/features/comment_feature_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+require_relative './helpers/users'
+
+feature 'Comment' do
+  scenario 'A participant can remove a comment they have added' do
+    participant = create(:user)
+    trip = create(:trip, participants: [participant])
+    destination = create(:trip_destination, trip: trip)
+
+    create(:comment, commentable: destination, author: participant)
+
+    login_user(participant)
+    click_link('My trips')
+    click_link(trip.name)
+    click_link('Remove')
+    expect(page).not_to have_content('My comment')
+  end
+
+  scenario 'A participant cannot remove a comment from another participant' do
+    participant = create(:user)
+    trip = create(:trip, participants: [participant])
+    destination = create(:trip_destination, trip: trip)
+
+    create(:comment, commentable: destination)
+
+    login_user(participant)
+    click_link('My trips')
+    click_link(trip.name)
+    expect(page).not_to have_selector(:link_or_button, 'Remove', exact: true)
+  end
+end

--- a/spec/features/date_feature_spec.rb
+++ b/spec/features/date_feature_spec.rb
@@ -18,6 +18,29 @@ feature 'Date' do
     expect(page).to have_content(range)
   end
 
+  scenario 'A participant can remove a date_option they have added' do
+    participant = create(:user)
+    trip = create(:trip, participants: [participant])
+    create(:trip_date_option, trip: trip, creator: participant.trip_participants.first)
+
+    login_user(participant)
+    click_link('My trips')
+    click_link('Reunion')
+    click_link('Remove')
+    expect(page).not_to have_content('Sarajevo')
+  end
+
+  scenario 'A participant cannot remove a date_option from someone else' do
+    participant = create(:user)
+    trip = create(:trip, participants: [participant])
+    create(:trip_date_option, trip: trip)
+
+    login_user(participant)
+    click_link('My trips')
+    click_link('Reunion')
+    expect(page).not_to have_selector(:link_or_button, 'Remove', exact: true)
+  end
+
   scenario 'A participant can comment on a date option' do
     login_user
     create_trip(name: 'A trip', description: 'Our trip to Italy')

--- a/spec/features/destination_feature_spec.rb
+++ b/spec/features/destination_feature_spec.rb
@@ -13,6 +13,29 @@ feature 'Destination' do
     expect(page).to have_content('Sarajevo option: Why we should go there')
   end
 
+  scenario 'A participant can remove a destination option they have added' do
+    participant = create(:user)
+    trip = create(:trip, participants: [participant])
+    create(:trip_destination, trip: trip, creator: participant.trip_participants.first)
+
+    login_user(participant)
+    click_link('My trips')
+    click_link('Reunion')
+    click_link('Remove')
+    expect(page).not_to have_content('Sarajevo')
+  end
+
+  scenario 'A participant cannot remove a destination option from someone else' do
+    participant = create(:user)
+    trip = create(:trip, participants: [participant])
+    create(:trip_destination, trip: trip)
+
+    login_user(participant)
+    click_link('My trips')
+    click_link('Reunion')
+    expect(page).not_to have_selector(:link_or_button, 'Remove', exact: true)
+  end
+
   scenario 'A participant can comment on a destination option' do
     login_user
     create_trip(name: 'A trip', description: 'Our trip to Italy')
@@ -53,14 +76,4 @@ def add_destination(name: 'Sarajevo option', description: 'Why we should go ther
   fill_in('trip_destination_name', with: name)
   fill_in('trip_destination_description', with: description)
   click_button('Add destination')
-end
-
-def wait_for_ajax
-  Timeout.timeout(Capybara.default_max_wait_time) do
-    loop until finished_all_ajax_requests?
-  end
-end
-
-def finished_all_ajax_requests?
-  page.evaluate_script('jQuery.active').zero?
 end

--- a/spec/features/trip_feature_spec.rb
+++ b/spec/features/trip_feature_spec.rb
@@ -22,115 +22,20 @@ feature 'Trip' do
 
   scenario 'An organiser can delete a trip' do
     user = create(:user)
-    create(:trip, organiser: user)
+    trip = create(:trip, organiser: user)
     login_user(user)
     click_link('My trips')
-    expect(page).to have_content('Sarajevo')
+    expect(page).to have_content(trip.name)
     click_link('Remove')
-    expect(page).to_not have_content('Sarajevo')
+    expect(page).to_not have_content(trip.name)
   end
 
   scenario 'A participant can not delete a trip' do
     user = create(:user)
-    create(:trip, participants: [user])
+    trip = create(:trip, participants: [user])
     login_user(user)
     click_link('My trips')
-    expect(page).to have_content('Sarajevo')
-    expect(page).not_to have_selector(:link_or_button, 'Remove', exact: true)
-  end
-
-  scenario 'A user can invite other people to a trip using their emails' do
-    login_user
-    create_trip(name: 'A trip', description: 'Our trip to Italy')
-    click_link('Trip invites')
-    fill_in('trip_invite_builder_emails', with: 'invite@email.com, invite2@email.com')
-    fill_in('trip_invite_builder_message', with: 'Trip invite message')
-    click_button('Send invitations')
-
-    expect(page).to have_content('Invitations')
-    expect(page).to have_content('invite@email.com')
-    expect(page).to have_content('invite2@email.com')
-    expect(page).not_to have_content('Trip invite description')
-
-    click_link('Back to trip')
-    expect(page).to have_content('Trip invites: 2 invitations')
-  end
-
-  scenario 'A user gets errors if emails are invalid and duplicate emails are not processed' do
-    login_user
-    create_trip(name: 'A trip', description: 'Our trip to Italy')
-    click_link('Trip invites')
-    fill_in('trip_invite_builder_emails', with: 'inviteemail.com, invite2@email.com, invite2@email.com')
-    fill_in('trip_invite_builder_message', with: 'Trip invite message')
-    click_button('Send invitations')
-
-    expect(page).to have_content('Email is invalid')
-    expect(find_field('Emails').value).to eq 'inviteemail.com'
-
-    click_link('Back to trip')
-    expect(page).to have_content('Trip invites: 1 invitations')
-  end
-
-  scenario 'The status of the invited users to the trip is shown' do
-    login_user
-    create_trip(name: 'A trip', description: 'Our trip to Italy')
-    click_link('Trip invites')
-    fill_in('trip_invite_builder_emails', with: 'invite@email.com, invite2@email.com, invite3@email.com')
-    fill_in('trip_invite_builder_message', with: 'Trip invite message')
-    click_button('Send invitations')
-
-    Trip::Invite.find_by(email: 'invite@email.com').update!(rvsp: true)
-    Trip::Invite.find_by(email: 'invite2@email.com').update!(rvsp: false)
-    visit current_path
-
-    expect(page).to have_content('Accepted')
-    expect(page).to have_content('Declined')
-    expect(page).to have_content('Pending')
-  end
-
-  scenario 'An existing user is added to participants if accepts invite' do
-    organiser = create(:user)
-    invitee = create(:user)
-    trip = create(:trip, organiser: organiser)
-    trip_invite = create(:trip_invite, trip: trip, email: invitee.email)
-    trip_invite.update!(rvsp: true)
-    login_user(invitee)
-    click_link('My trips')
-    expect(page).to have_content('Sarajevo')
-  end
-
-  scenario 'An organiser can remove a participant from the trip' do
-    organiser = create(:user)
-    invitee = create(:user)
-    trip = create(:trip, name: 'Sarajevo', organiser: organiser)
-    trip_invite = create(:trip_invite, trip: trip, email: invitee.email)
-    trip_invite.update!(rvsp: true)
-
-    login_user(organiser)
-    click_link('My trips')
-    click_link('Sarajevo')
-    click_link('Trip invites')
-    click_link('Remove')
-    click_link('Back to trip')
-    expect(page).to have_content('Trip invites: 0 invitations')
-
-    sign_out(organiser)
-    sign_in(invitee)
-    click_link('My trips')
-    expect(page).to_not have_content('Sarajevo')
-  end
-
-  scenario 'A participant does not have the remove invite option' do
-    invitee = create(:user)
-    trip = create(:trip, name: 'Sarajevo', participants: [invitee])
-    trip_invite = create(:trip_invite, trip: trip, email: 'test@email.com')
-    trip_invite.update!(rvsp: true)
-
-    login_user(invitee)
-    click_link('My trips')
-    click_link('Sarajevo')
-    expect(page).to have_content('Trip invites: 1 invitations')
-    click_link('Trip invites')
+    expect(page).to have_content(trip.name)
     expect(page).not_to have_selector(:link_or_button, 'Remove', exact: true)
   end
 end

--- a/spec/features/trip_participant_feature_spec.rb
+++ b/spec/features/trip_participant_feature_spec.rb
@@ -1,0 +1,100 @@
+require 'rails_helper'
+require_relative './helpers/users'
+require_relative './helpers/trip'
+
+feature 'Trip' do
+  scenario 'A user can invite other people to a trip using their emails' do
+    login_user
+    create_trip(name: 'A trip', description: 'Our trip to Italy')
+    click_link('Trip invites')
+    fill_in('trip_invite_builder_emails', with: 'invite@email.com, invite2@email.com')
+    fill_in('trip_invite_builder_message', with: 'Trip invite message')
+    click_button('Send invitations')
+
+    expect(page).to have_content('Invitations')
+    expect(page).to have_content('invite@email.com')
+    expect(page).to have_content('invite2@email.com')
+    expect(page).not_to have_content('Trip invite description')
+
+    click_link('Back to trip')
+    expect(page).to have_content('Trip invites: 2 invitations')
+  end
+
+  scenario 'A user gets errors if emails are invalid and duplicate emails are not processed' do
+    login_user
+    create_trip(name: 'A trip', description: 'Our trip to Italy')
+    click_link('Trip invites')
+    fill_in('trip_invite_builder_emails', with: 'inviteemail.com, invite2@email.com, invite2@email.com')
+    fill_in('trip_invite_builder_message', with: 'Trip invite message')
+    click_button('Send invitations')
+
+    expect(page).to have_content('Email is invalid')
+    expect(find_field('Emails').value).to eq 'inviteemail.com'
+
+    click_link('Back to trip')
+    expect(page).to have_content('Trip invites: 1 invitations')
+  end
+
+  scenario 'The status of the invited users to the trip is shown' do
+    login_user
+    create_trip(name: 'A trip', description: 'Our trip to Italy')
+    click_link('Trip invites')
+    fill_in('trip_invite_builder_emails', with: 'invite@email.com, invite2@email.com, invite3@email.com')
+    fill_in('trip_invite_builder_message', with: 'Trip invite message')
+    click_button('Send invitations')
+
+    Trip::Invite.find_by(email: 'invite@email.com').update!(rvsp: true)
+    Trip::Invite.find_by(email: 'invite2@email.com').update!(rvsp: false)
+    visit current_path
+
+    expect(page).to have_content('Accepted')
+    expect(page).to have_content('Declined')
+    expect(page).to have_content('Pending')
+  end
+
+  scenario 'An existing user is added to participants if accepts invite' do
+    organiser = create(:user)
+    invitee = create(:user)
+    trip = create(:trip, organiser: organiser)
+    trip_invite = create(:trip_invite, trip: trip, email: invitee.email)
+    trip_invite.update!(rvsp: true)
+    login_user(invitee)
+    click_link('My trips')
+    expect(page).to have_content(trip.name)
+  end
+
+  scenario 'An organiser can remove a participant from the trip' do
+    organiser = create(:user)
+    invitee = create(:user)
+    trip = create(:trip, organiser: organiser)
+    trip_invite = create(:trip_invite, trip: trip, email: invitee.email)
+    trip_invite.update!(rvsp: true)
+
+    login_user(organiser)
+    click_link('My trips')
+    click_link(trip.name)
+    click_link('Trip invites')
+    click_link('Remove')
+    click_link('Back to trip')
+    expect(page).to have_content('Trip invites: 0 invitations')
+
+    sign_out(organiser)
+    sign_in(invitee)
+    click_link('My trips')
+    expect(page).to_not have_content(trip.name)
+  end
+
+  scenario 'A participant does not have the remove invite option' do
+    invitee = create(:user)
+    trip = create(:trip, participants: [invitee])
+    trip_invite = create(:trip_invite, trip: trip, email: 'test@email.com')
+    trip_invite.update!(rvsp: true)
+
+    login_user(invitee)
+    click_link('My trips')
+    click_link(trip.name)
+    expect(page).to have_content('Trip invites: 1 invitations')
+    click_link('Trip invites')
+    expect(page).not_to have_selector(:link_or_button, 'Remove', exact: true)
+  end
+end

--- a/spec/features/user_feature_spec.rb
+++ b/spec/features/user_feature_spec.rb
@@ -30,7 +30,7 @@ feature 'Add invitations when signup' do
       create(:trip_invite, email: 'invite@email.com', rvsp: true, responded_at: Time.zone.now)
       sign_up(email: 'invite@email.com')
       click_link('My trips')
-      expect(page).to have_content('Sarajevo')
+      expect(page).to have_content('Reunion')
     end
   end
 end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -34,4 +34,46 @@ describe Ability do
       it { is_expected.to be_able_to(:destroy, trip_invite) }
     end
   end
+
+  describe 'trip destination' do
+    context 'the creator' do
+      let(:trip) { create(:trip, organiser: user) }
+      let(:trip_destination) { create(:trip_destination, trip: trip, creator: user.trip_participants.first) }
+      it { is_expected.to be_able_to(:destroy, trip_destination) }
+    end
+
+    context 'a participant' do
+      let(:trip) { create(:trip, participants: [user]) }
+      let(:trip_destination) { create(:trip_destination, trip: trip) }
+
+      it { is_expected.not_to be_able_to(:destroy, trip_destination) }
+    end
+  end
+
+  describe 'trip date option' do
+    context 'the creator' do
+      let(:trip) { create(:trip, organiser: user) }
+      let(:trip_date_option) { create(:trip_date_option, trip: trip, creator: user.trip_participants.first) }
+      it { is_expected.to be_able_to(:destroy, trip_date_option) }
+    end
+
+    context 'a participant' do
+      let(:trip) { create(:trip, participants: [user]) }
+      let(:trip_date_option) { create(:trip_date_option, trip: trip) }
+
+      it { is_expected.not_to be_able_to(:destroy, trip_date_option) }
+    end
+  end
+
+  describe 'comment' do
+    context 'the author' do
+      let(:comment) { create(:comment, author: user) }
+      it { is_expected.to be_able_to(:destroy, comment) }
+    end
+
+    context 'not the author' do
+      let(:comment) { create(:comment) }
+      it { is_expected.to_not be_able_to(:destroy, comment) }
+    end
+  end
 end


### PR DESCRIPTION
The creator of a comment, date option and destination can delete their
input. This option is not visible to the non-creator participant.

Creator is the trip participant, so that it is easier to isolate various
content per trip rather than per user. Creator id is added when the
date option and destination is created.